### PR TITLE
Modernize CI workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   pr-pull:
     if: contains(github.event.pull_request.labels.*.name, 'pr-pull')
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       packages: none

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-13]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew
@@ -19,7 +19,7 @@ jobs:
 
       - name: Cache Homebrew Bundler RubyGems
         id: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
           key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
@@ -40,7 +40,7 @@ jobs:
 
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: bottles
+          name: bottles-${{ matrix.os }}
           path: '*.bottle.*'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
+    env:
+      HOMEBREW_NO_SANDBOX_LINUX: "1"
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew

--- a/Formula/mangathr.rb
+++ b/Formula/mangathr.rb
@@ -2,8 +2,8 @@ class Mangathr < Formula
   desc "Terminal utility for downloading manga with support for MangaDex & Cubari"
   homepage "https://github.com/browningluke/mangathr"
   url "https://github.com/browningluke/mangathr.git",
-      tag:      "v2.4.0",
-      revision: "f021dd0dae713261df89af72aff3598c367fe411"
+      tag:      "v2.7.0",
+      revision: "f3aab485ad65825a516727c5ae719e166048f044"
   license "MIT"
   head "https://github.com/browningluke/mangathr.git", branch: "main"
 


### PR DESCRIPTION
- `actions/cache` v3 → v4
- `actions/upload-artifact` v3 → v4 (per-OS artifact name to avoid matrix conflicts)
- Pinned runners → `ubuntu-latest` / `macos-latest`